### PR TITLE
Updated for Ruby 2.3, added Travis CI build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,14 @@
+cache: bundler
+sudo: false
+matrix:
+  fast_finish: true
+branches:
+  only: master
+rvm:
+  - 1.9.3
+  - 2.0.0
+  - 2.1.0
+  - 2.2.0
+  - 2.3.0
+  - 2.4.0
+script: bundle exec rspec

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,10 +5,8 @@ matrix:
 branches:
   only: master
 rvm:
-  - 1.9.3
   - 2.0.0
   - 2.1.0
   - 2.2.0
   - 2.3.0
-  - 2.4.0
 script: bundle exec rspec

--- a/Gemfile
+++ b/Gemfile
@@ -1,2 +1,3 @@
 source :rubygems
 gemspec
+gem 'rspec-its'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,20 +8,40 @@ PATH
 GEM
   remote: http://rubygems.org/
   specs:
-    diff-lcs (1.1.3)
+    diff-lcs (1.3)
+    domain_name (0.5.20170404)
+      unf (>= 0.0.5, < 1.0.0)
     fakeweb (1.3.0)
-    json (1.7.6)
-    mime-types (1.19)
-    rest-client (1.6.7)
-      mime-types (>= 1.16)
-    rspec (2.7.0)
-      rspec-core (~> 2.7.0)
-      rspec-expectations (~> 2.7.0)
-      rspec-mocks (~> 2.7.0)
-    rspec-core (2.7.1)
-    rspec-expectations (2.7.0)
-      diff-lcs (~> 1.1.2)
-    rspec-mocks (2.7.0)
+    http-cookie (1.0.3)
+      domain_name (~> 0.5)
+    json (2.1.0)
+    mime-types (3.1)
+      mime-types-data (~> 3.2015)
+    mime-types-data (3.2016.0521)
+    netrc (0.11.0)
+    rest-client (2.0.2)
+      http-cookie (>= 1.0.2, < 2.0)
+      mime-types (>= 1.16, < 4.0)
+      netrc (~> 0.8)
+    rspec (3.7.0)
+      rspec-core (~> 3.7.0)
+      rspec-expectations (~> 3.7.0)
+      rspec-mocks (~> 3.7.0)
+    rspec-core (3.7.1)
+      rspec-support (~> 3.7.0)
+    rspec-expectations (3.7.0)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.7.0)
+    rspec-its (1.2.0)
+      rspec-core (>= 3.0.0)
+      rspec-expectations (>= 3.0.0)
+    rspec-mocks (3.7.0)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.7.0)
+    rspec-support (3.7.1)
+    unf (0.1.4)
+      unf_ext
+    unf_ext (0.0.7.5)
 
 PLATFORMS
   ruby
@@ -30,3 +50,7 @@ DEPENDENCIES
   fakeweb (>= 1.3.0)
   mixcloud!
   rspec (>= 2.7.0)
+  rspec-its
+
+BUNDLED WITH
+   1.16.1

--- a/README.rdoc
+++ b/README.rdoc
@@ -1,4 +1,4 @@
-== Mixcloud [![Build Status](https://travis-ci.org/actfong/mixcloud.svg?branch=master)](https://travis-ci.org/actfong/mixcloud)
+== Mixcloud {<img src="https://travis-ci.org/actfong/mixcloud.svg?branch=master" alt="Build Status" />}[https://travis-ci.org/actfong/mixcloud]
 
 The Mixcloud gem is a ruby wrapper of the Mixcloud.com API.
 It enables you to create Ruby objects of Mixcloud resources such as Cloudcast, Artist, etc. by providing their API urls.

--- a/README.rdoc
+++ b/README.rdoc
@@ -1,4 +1,4 @@
-== Mixcloud
+== Mixcloud [![Build Status](https://travis-ci.org/actfong/mixcloud.svg?branch=master)](https://travis-ci.org/actfong/mixcloud)
 
 The Mixcloud gem is a ruby wrapper of the Mixcloud.com API.
 It enables you to create Ruby objects of Mixcloud resources such as Cloudcast, Artist, etc. by providing their API urls.
@@ -8,6 +8,10 @@ For more info check
 * www.mixcloud.com/developers/documentation/
 
 This gem has not yet been tested with a Rails app. So it is still pretty much a beta. But feel free to test it, use it, drop me a note if you think something needs to be changed or added, or if something isn't quite working.
+
+== Requirements
+
+Ruby >= 2.0 is supported, except for 2.4 which is currently broken due an issue with the `fakeweb` gem dependency. Once fakeweb is updated we can update to add support.
 
 == Installation
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,9 +1,10 @@
 require 'rspec'
 require 'mixcloud'
 require 'fakeweb'
+require 'rspec/its'
 
 RSpec.configure do |config|
-  config.color_enabled = true
+  config.color = true
   config.formatter = 'documentation'
 end
 


### PR DESCRIPTION
You can see the passing build [here](https://travis-ci.org/szTheory/mixcloud). Please note that the build fails for Ruby 1.9.3 and Ruby 2.4, which you can see [here](https://travis-ci.org/szTheory/mixcloud/builds/364816043). The reason for Ruby 2.4 incompatibility is an issue with the [current version of fakeweb](https://github.com/chrisk/fakeweb). If you look at the [latest Issues for fakeweb](https://github.com/chrisk/fakeweb/issues/62) you'll see that it hasn't been updated in many years, an while the maintainer says or plans on updating it there hasn't been any movement in the past year so I wouldn't hold my breath on it.